### PR TITLE
Update the Editors and Team info page

### DIFF
--- a/site/content/about/core/_index.md
+++ b/site/content/about/core/_index.md
@@ -12,7 +12,7 @@ toc    = true
 
 This page lists individuals and groups who have (or have had) specific roles, but this short list is not meant to diminish the contributions of the broader community of people and companies developing software systems that use SBML. People's involvements also change over time, and we try to keep this page updated to stay current with the SBML community.
 
-## SBML Editors and SBML Coordinator
+## SBML Editors
 
 The SBML Editors are devoted experts who develop specifications, correct errata, assess proposals, and manage revisions to SBML. The five Editors are elected by the SBML community and serve for three-year terms as volunteers.  One of the Editors is nominated by the other Editors to be Coordinator and lead activities such as organizing and chairing Editor meetings, monitoring progress on new SBML developments, and managing community votes.
 
@@ -21,8 +21,6 @@ The SBML Editors are devoted experts who develop specifications, correct errata,
 The following are the current SBML Editors (in alphabetical order):
 
   - [**Frank T. Bergmann**](http://frank-fbergmann.blogspot.com/) (Ph.D. in Computational & Systems Biology) is a member of the Centre for Organismal Studies at the University of Heidelberg, Germany, and a member of the COPASI Team.  He has been involved in the development of [libSBML](/software/libsbml), [Deviser](/software/deviser), the [SBML Test Suite](/software/sbml-test-suite) and the Test Suite Database, the Online SBML Validator, the SBML Showcase, and many other tools and resources for SBML. (Current term as Editor: 2020&ndash;2022.)
-
-  - **Sarah M. Keating** (Ph.D. in Electrical & Electronic Engineering) is based at the [EBI](http://www.ebi.ac.uk) and works on software tools to facilitate the use of SBML. She is the lead developer for [libSBML](http://sbml.org/Software/libSBML) and [Deviser](https://github.com/sbmlteam/deviser) and is involved in developing many other tools/facilities for SBML, including the [SBML Test Suite](http://sbml.org/Software/SBML_Test_Suite), RELAX NG schemas for SBML, and more.  (SBML Coordinator.)
 
   - [**Matthias König**](https://livermetabolism.com/cv/) (Ph.D.  in Biophysics) leads a [junior research group](https://livermetabolism.com) for Systems Biology and Systems Medicine of the liver at the [Humboldt University Berlin](https://www.hu-berlin.de). His research areas include computational modeling, data science, development of bioinformatics methods and software.  He has been actively involved in the development of [SBML](http://sbml.org), [SED-ML](http://sed-ml.org) and software supporting these standards. Lead-developer of [cy3sbml](https://github.com/matthiaskoenig/cy3sbml), [sbmlutils](https://github.com/matthiaskoenig/sbmlutils), and [sbmlsim](https://github.com/matthiaskoenig/sbmlsim); contributor to [libroadrunner](http://libroadrunner.org/), [tellurium](http://tellurium.analogmachine.org/), [cobrapy](https://github.com/opencobra/cobrapy/) and more.  (Current term as Editor:  2021&ndash;2023.)
 
@@ -37,6 +35,20 @@ The SBML Editors can be reached via email at [sbml-editors@googlegroups.com](mai
 ### Past SBML Editors
 
 Past SBML Editors have been (in reverse chronological order) [Matthias König](https://livermetabolism.com/cv/) (2018&ndash;2020), [Claudine Chaouiya](http://compbio.igc.gulbenkian.pt/nmd/node/14) (2017&ndash;2019), [Fengkai Zhang](https://www.linkedin.com/in/fengkai-zhang-8aba2018) (2017&ndash;2019), [Andreas Dräger](https://uni-tuebingen.de/en/134053) (2015&ndash;2017), [Dagmar Waltemath](http://www.sbi.uni-rostock.de/team/single/dagmar-waltemath/) (2014–2016), [Brett G. Olivier](https://research.vu.nl/en/persons/bg-olivier) (2014–2016), [Frank Bergmann](http://frank-fbergmann.blogspot.com/) (2009–2011, 2013–2015), Sven Sahle (2008–2010, 2013–2015), Sarah M. Keating (2007–2009, 2011–2013, 2016–2018), [Chris J.  Myers](http://www.async.ece.utah.edu/~myers/) (2011–2013), [James C.Schaff](http://www.ccam.uchc.edu/people/schaff/schaff.html) (2010–2012), Lucian Smith (2010–2012), [Darren Wilkinson](http://www.staff.ncl.ac.uk/d.j.wilkinson/) (2008–2010), Stefan Hoops (2007–2009), [Nicolas Le Novère](https://lenoverelab.org/members/Nicolas_Le_Novere) (2006–2008, 2012–2014, 2016–2018), [Michael Hucka](http://www.cds.caltech.edu/~mhucka/) (2000–2015), [Andrew M.  Finney](http://uk.linkedin.com/in/andrewmartinfinney) (2000–2006), [Herbert M.  Sauro](http://depts.washington.edu/bioe/people/core/sauro/sauro.html) (2000–2006), and [Hamid Bolouri](http://www.its.caltech.edu/~hbolouri/) (2000–2006). The SBML effort and community benefited tremendously from their involvement and hard work.
+
+## SBML COMBINE Coordinator
+
+SBML is one of the founding standards of [COMBINE](http://co.mbine.org/) the computational modeling in biology network. Each of the COMBINE standards nominates a representative to sit on the COMBINE Coordination Board.
+
+### Current COMBINE Coordinator 
+
+ - **Sarah M. Keating** (Ph.D. in Electrical & Electronic Engineering) is a Senior Research Software Developer at [UCL](https://www.ucl.ac.uk/isd/services/research-it/research-software-development). She worked as member of the SBML Team from 2002 - 2019. She maintains the role of lead developer for [libSBML](http://sbml.org/Software/libSBML) and [Deviser](https://github.com/sbmlteam/deviser) and has been involved in developing many other tools/facilities for SBML, including the [SBML Test Suite](http://sbml.org/Software/SBML_Test_Suite), RELAX NG schemas for SBML, and more.
+
+### Past COMBINE Coordinators
+
+[Michael Hucka](http://www.cds.caltech.edu/~mhucka/)
+
+ 
 
 ## SBML Scientific Advisory Board
 

--- a/site/content/about/core/_index.md
+++ b/site/content/about/core/_index.md
@@ -68,15 +68,19 @@ The SBML Scientific Advisory Board is composed of scientists and researchers wit
 
 ## SBML Team
 
-The SBML Team strives to support the SBML community and the development and maintenance of specific SBML infrastructure and facilities. In particular, the team is responsible for (1) maintaining this website, the SBML mailing lists, electronic surveys, and other resources; (2) arranging for the development and support of critical software, including [libSBML](Software/libSBML), the [SBML Validator](Facilities/Validator), and the SBML Test Suite; and (3) organizing [SBML events](Events).
+The SBML Team has been funded to support the SBML community and the development and maintenance of specific SBML infrastructure and facilities. In particular, the team was responsible for (1) maintaining this website, the SBML mailing lists, electronic surveys, and other resources; (2) arranging for the development and support of critical software, including [libSBML](Software/libSBML), the [SBML Validator](Facilities/Validator), and the SBML Test Suite; and (3) organizing [SBML events](Events).
+
+Unfortunately there is no longer any formal funding but the following people contribute their time to maintaining the infrastructure they worked so long to develop.  
 
 Email address for contacting the SBML Team: <sbml-team@googlegroups.com>
 
   - [**Michael Hucka**](http://www.cds.caltech.edu/~mhucka/) works on all aspects of SBML and contributes to [libSBML](Software/libSBML "wikilink"), the SBML Test Suite, and the Online SBML Validator. He also writes grant proposals, organizes workshops, maintains SBML.org, and does other odd jobs.
 
+  - [**Frank Bergmann**](http://frank-fbergmann.blogspot.com/) worked on many software systems and services, including the online SBML validator, the SBML Test Suite, the SBML Test Suite Database, libSBML, and more. He still contributes to these efforts.
+
   - [**Andreas Dräger**](https://uni-tuebingen.de/en/134053) is a junior professor at the [Institute for Bioinformatics and Medical Informatics (IBMI) in Tübingen](https://uni-tuebingen.de/en/148353), and is also a co-developer of [JSBML](Software/JSBML "wikilink") and several upcoming software efforts by the SBML Team.
 
-  - **Sarah M. Keating** is the current lead developer for [libSBML](Software/libSBML "wikilink") and the [ SBMLToolbox](Software/SBMLToolbox "wikilink"). She is also developing the SBML Test Suite, the RELAX NG schemas for SBML, and [DEVISER](http://www.github.com/sbmlteam/deviser).
+  - **Sarah M. Keating** is a Senior Research Software Developer at [UCL](https://www.ucl.ac.uk/isd/services/research-it/research-software-development). She still maintains the development for [libSBML](Software/libSBML "wikilink"), [ SBMLToolbox](Software/SBMLToolbox "wikilink"), and [DEVISER](http://www.github.com/sbmlteam/deviser).
 
   - **Lucian P. Smith** leads the development of the SBML Level 3 [ hierarchical model composition](Community/Wiki/SBML_Level_3_Proposals/Hierarchical_Model_Composition "wikilink") package. He also works on the SBML Test Suite.
 


### PR DESCRIPTION
I changed the Editors section to not mention a coordinator and put in a section on SBML COMBINE Coord

I changed the text about SBML Team to indicate we are no longer funded and added Frank back to the list of people working pro bono.

Updated text about me. 