### PR TITLE
fix broken specification links, fix #45

### DIFF
--- a/site/data/SBML.toml
+++ b/site/data/SBML.toml
@@ -42,7 +42,7 @@
     title       = "Systems Biology Markup Language (SBML) Level 1: Structures and Facilities for Basic Model Definitions"
     date        = "2001-03-02"
     authors     = "Michael Hucka, Andrew Finney, Herbert Sauro, and Hamid Bolouri"
-    pdf_main    = "http://co.mbine.org/specifications/sbml.level-1.version-1"
+    pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-1.version-1"
     pdf_alt     = "/documents/specifications/level-1/version-1/sbml.level-1.version-1.pdf"
     citation    = "Michael Hucka, Andrew Finney, Herbert Sauro, Hamid Bolouri. (2001). Systems Biology Markup Language (SBML) Level 1: Structures and Facilities for Basic Model Definitions. Retrieved from COMBINE, http<i></i>://identifiers.org/combine.specifications/sbml.level-1.version-1"
     pub_url     = "none"
@@ -59,7 +59,7 @@
     title       = "Systems Biology Markup Language (SBML) Level 1: Structures and Facilities for Basic Model Definitions"
     date        = "2003-08-28"
     authors     = "Michael Hucka, Andrew Finney, Herbert Sauro, and Hamid Bolouri"
-    pdf_main    = "http://co.mbine.org/specifications/sbml.level-1.version-2"
+    pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-1.version-2"
     pdf_alt     = "/documents/specifications/level-1/version-2/sbml.level-1.version-2.pdf"
     citation    = "Michael Hucka, Andrew Finney, Herbert Sauro, Hamid Bolouri. (2001). Systems Biology Markup Language (SBML) Level 1: Structures and Facilities for Basic Model Definitions. Retrieved from COMBINE, http<i></i>://identifiers.org/combine.specifications/sbml.level-1.version-2"
     pub_url     = "none"
@@ -68,7 +68,7 @@
     schema      = "/documents/specifications/level-1/version-2/sbml.level-1.version-2.xsd"
     issue_list  = "/documents/specifications/level-1/version-2/issues"
     tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+1+Version+2%22"
-      
+
   [spec.core.level-2]
   highest_version = 5
 
@@ -79,7 +79,7 @@
     title       = "Systems Biology Markup Language (SBML) Level 2: Structures and Facilities for Model Definitions"
     date        = "2003-06-28"
     authors     = "Andrew Finney and Michael Hucka"
-    pdf_main    = "http://co.mbine.org/specifications/sbml.level-2.version-1"
+    pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-2.version-1"
     pdf_alt     = "/documents/specifications/level-2/version-1/sbml.level-2.version-1.pdf"
     citation    = "Andrew M. Finney and Michael Hucka. (2003). Systems Biology Markup Language (SBML) Level 2: Structures and Facilities for Model Definitions. Retrieved from COMBINE, http<i></i>://identifiers.org/combine.specifications/sbml.level-2.version-1"
     pub_url     = "none"
@@ -88,7 +88,7 @@
     schema      = "/documents/specifications/level-2/version-1/sbml.level-2.version-1.xsd"
     issue_list  = "/documents/specifications/level-2/version-1/issues"
     tracker     = "https://github.com/sbmlteam/sbml-specifications/issues"
-    
+
     [spec.core.level-2.version-2.revision-1]
     level       = "2"
     version     = "2"
@@ -97,7 +97,7 @@
     title       = "Systems Biology Markup Language (SBML) Level 2: Structures and Facilities for Model Definitions"
     date        = "2006-09-26"
     authors     = "Andrew Finney, Michael Hucka, and Nicolas Le Novère"
-    pdf_main    = "http://co.mbine.org/specifications/sbml.level-2.version-2"
+    pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-2.version-2"
     pdf_alt     = "/documents/specifications/level-2/version-2/revision-1/sbml.level-2.version-2.revision-1.pdf"
     citation    = "Andrew M. Finney, Nicolas Le Novère, and Michael Hucka. (2006). Systems Biology Markup Language (SBML) Level 2: Structures and Facilities for Model Definitions. Retrieved from COMBINE, http<i></i>://identifiers.org/combine.specifications/sbml.level-2.version-2"
     pub_url     = "none"
@@ -126,7 +126,7 @@
       schema      = "/documents/specifications/level-2/version-3/release-1/sbml.level-2.version-3.release-1.xsd"
       issue_list  = "/documents/specifications/level-2/version-3/release-1/issues"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+2+Version+3%22"
-  
+
       [spec.core.level-2.version-3.release-2]
       level       = "2"
       version     = "3"
@@ -143,7 +143,7 @@
       schema      = "/documents/specifications/level-2/version-3/release-2/sbml.level-2.version-3.release-2.xsd"
       issue_list  = "/documents/specifications/level-2/version-3/release-2/issues"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+2+Version+3%22"
-  
+
     [spec.core.level-2.version-4]
     highest_release = 1
 
@@ -163,7 +163,7 @@
       schema      = "/documents/specifications/level-2/version-4/release-1/sbml.level-2.version-4.release-1.xsd"
       issue_list  = "/documents/specifications/level-2/version-4/release-1/issues"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+2+Version+4%22"
-    
+
     [spec.core.level-2.version-5]
     highest_release = 1
 
@@ -174,7 +174,7 @@
       title       = "Systems Biology Markup Language (SBML) Level 2: Structures and Facilities for Model Definitions"
       date        = "2015-08-03"
       authors     = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, and Darren J. Wilkinson"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-2.version-5.release-1"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-2.version-5.release-1"
       pdf_alt     = "/documents/specifications/level-2/version-5/release-1/sbml.level-2.version-5.release-1.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, and Darren J. Wilkinson. (2015). Systems Biology Markup Language (SBML) Level 2 Version 5: Structures and Facilities for Model Definitions. _Journal of Integrative Bioinformatics_, 12(2), 271"
       pub_url     = "https://doi.org/10.2390/biecoll-jib-2015-271"
@@ -183,7 +183,7 @@
       schema      = "/documents/specifications/level-2/version-5/release-1/sbml.level-2.version-5.release-1.xsd"
       issue_list  = "/documents/specifications/level-2/version-5/release-1/issues"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/labels/Level%202%20Version%205%20Core"
-    
+
   [spec.core.level-3]
   highest_version = 2
 
@@ -197,7 +197,7 @@
       title       = "The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core"
       date        = "2010-10-06"
       authors     = "Michael Hucka, Frank T. Bergmann, Stefan Hoops, Sarah M. Keating, Sven Sahle, James C. Schaff, Lucian P. Smith, and Darren J. Wilkinson"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-3.version-1.core.release-1"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-3.version-1.core.release-1"
       pdf_alt     = "/documents/specifications/level-3/version-1/core/release-1/sbml.level-3.version-1.core.release-1.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Stefan Hoops, Sarah M. Keating, Sven Sahle, James C. Schaff, Lucian P. Smith, and Darren J. Wilkinson. (2015). The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core. _Journal of Integrative Bioinformatics_, 12(2), 382-549"
       pub_url     = "https://doi.org/10.1515/jib-2015-266"
@@ -206,7 +206,7 @@
       issue_list  = "/documents/specifications/level-3/version-1/core/release-1/issues"
       schema      = "https://github.com/sbmlteam/sbml-specifications/tree/release/RelaxNG/sbml-core"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+3+Version+1+Core%22"
-  
+
       [spec.core.level-3.version-1.release-2]
       level       = "3"
       version     = "1"
@@ -214,7 +214,7 @@
       title       = "The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core"
       date        = "2016-12-28"
       authors     = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, and Darren J. Wilkinson"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-3.version-1.core.release-2"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-3.version-1.core.release-2"
       pdf_alt     = "/documents/specifications/level-3/version-1/core/release-2/sbml.level-3.version-1.core.release-2.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicholas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, and Darren J. Wilkinson. (2018). The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core. _Journal of Integrative Bioinformatics_, 15(1), 20170080"
       pub_url     =  "https://doi.org/10.1515/jib-2017-0080"
@@ -223,7 +223,7 @@
       issue_list  = "/documents/specifications/level-3/version-1/core/release-2/issues"
       schema      = "https://github.com/sbmlteam/sbml-specifications/tree/release/RelaxNG/sbml-core"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+3+Version+1+Release+2+Core%22"
-  
+
       [spec.core.level-3.version-1.release-3]
       level       = "3"
       version     = "1"
@@ -231,7 +231,7 @@
       title       = "The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core"
       date        = "2019-03-29"
       authors     = "Michael Hucka, Frank T. Bergmann, Claudine Chaouiya, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Matthias König, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Rahuman Sheriff, Lucian P. Smith, Dagmar Waltemath, Darren J. Wilkinson and Fengkai Zhang"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-3.version-1.core.release-3"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-3.version-1.core.release-3"
       pdf_alt     = "/documents/specifications/level-3/version-1/core/release-3/sbml.level-3.version-1.core.release-3.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Claudine Chaouiya, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Matthias König, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Rahuman Sheriff, Lucian P. Smith, Dagmar Waltemath, Darren J. Wilkinson and Fengkai Zhang. (2019). The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 1 Core. Retrieved from COMBINE, http<i></i>://identifiers.org/combine.specifications/sbml.level-3.version-1.release-3"
       pub_url     = ""
@@ -240,7 +240,7 @@
       issue_list  = "/documents/specifications/level-3/version-1/core/release-3/issues"
       schema      = "https://github.com/sbmlteam/sbml-specifications/tree/release/RelaxNG/sbml-core"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+3+Version+1+Release+3+Core%22"
-    
+
     [spec.core.level-3.version-2]
     highest_release = 2
 
@@ -251,7 +251,7 @@
       title       = "The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 2 Core"
       date        = "2017-12-05"
       authors     = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, Darren J. Wilkinson"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-3.version-2.core.release-1"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-3.version-2.core.release-1"
       pdf_alt     = "/documents/specifications/level-3/version-2/core/release-1/sbml.level-3.version-2.core.release-1.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Nicholas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Lucian P. Smith, Dagmar Waltemath, and Darren J. Wilkinson. (2017). The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 2 Core. _Journal of Integrative Bioinformatics_, 15(1), 20170081"
       pub_url     = "https://doi.org/10.1515/jib-2017-0081"
@@ -260,7 +260,7 @@
       issue_list  = "/documents/specifications/level-3/version-2/core/release-1/issues"
       schema      = "https://github.com/sbmlteam/sbml-specifications/tree/release/RelaxNG/sbml-core"
       tracker     = "https://github.com/sbmlteam/sbml-specifications/issues?q=label%3A%22Level+3+Version+2+Core%22"
-  
+
       [spec.core.level-3.version-2.release-2]
       level       = "3"
       version     = "2"
@@ -268,7 +268,7 @@
       title       = "The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 2 Core"
       date        = "2019-03-29"
       authors     = "Michael Hucka, Frank T. Bergmann, Claudine Chaouiya, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Matthias König, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Rahuman Sheriff, Lucian P. Smith, Dagmar Waltemath, Darren J. Wilkinson, and Fengkai Zhang"
-      pdf_main    = "http://co.mbine.org/specifications/sbml.level-3.version-2.core.release-2"
+      pdf_main    = "https://identifiers.org/combine.specifications:sbml.level-3.version-2.core.release-2"
       pdf_alt     = "/documents/specifications/level-3/version-2/core/release-2/sbml.level-3.version-2.core.release-2.pdf"
       citation    = "Michael Hucka, Frank T. Bergmann, Claudine Chaouiya, Andreas Dräger, Stefan Hoops, Sarah M. Keating, Matthias König, Nicolas Le Novère, Chris J. Myers, Brett G. Olivier, Sven Sahle, James C. Schaff, Rahuman Sheriff, Lucian P. Smith, Dagmar Waltemath, Darren J. Wilkinson, and Fengkai Zhang (2019). The Systems Biology Markup Language (SBML): Language Specification for Level 3 Version 2 Core Release 2. _Journal of Integrative Bioinformatics_, 16(2), 20190021"
       pub_url     =  "https://doi.org/10.1515/jib-2019-0021"

--- a/site/static/software/libsbml/5.18.0/docs/formatted/c-api/libsbml-sbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/c-api/libsbml-sbml-specifications.html
@@ -63,8 +63,8 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
                onmouseout="return searchBox.OnSearchSelectHide()"
                alt=""/>
           <input type="text" id="MSearchField" value="Search" accesskey="S"
-               onfocus="searchBox.OnSearchFieldFocus(true)" 
-               onblur="searchBox.OnSearchFieldFocus(false)" 
+               onfocus="searchBox.OnSearchFieldFocus(true)"
+               onblur="searchBox.OnSearchFieldFocus(false)"
                onkeyup="searchBox.OnSearchFieldChange(event)"/>
           </span><span class="right">
             <a id="MSearchClose" href="javascript:searchBox.CloseResultsWindow()"><img id="MSearchCloseImg" border="0" src="search/close.png" alt=""/></a>
@@ -80,7 +80,7 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
       <div id="nav-sync" class="sync"></div>
     </div>
   </div>
-  <div id="splitbar" style="-moz-user-select:none;" 
+  <div id="splitbar" style="-moz-user-select:none;"
        class="ui-resizable-handle">
   </div>
 </div>
@@ -97,7 +97,7 @@ $(document).ready(function(){initNavTree('libsbml-sbml-specifications.html','');
 
 <!-- iframe showing the search results (closed by default) -->
 <div id="MSearchResultsWindow">
-<iframe src="javascript:void(0)" frameborder="0" 
+<iframe src="javascript:void(0)" frameborder="0"
         name="MSearchResults" id="MSearchResults">
 </iframe>
 </div>
@@ -123,7 +123,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -136,7 +136,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/formatted/cpp-api/libsbml-sbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/cpp-api/libsbml-sbml-specifications.html
@@ -63,8 +63,8 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
                onmouseout="return searchBox.OnSearchSelectHide()"
                alt=""/>
           <input type="text" id="MSearchField" value="Search" accesskey="S"
-               onfocus="searchBox.OnSearchFieldFocus(true)" 
-               onblur="searchBox.OnSearchFieldFocus(false)" 
+               onfocus="searchBox.OnSearchFieldFocus(true)"
+               onblur="searchBox.OnSearchFieldFocus(false)"
                onkeyup="searchBox.OnSearchFieldChange(event)"/>
           </span><span class="right">
             <a id="MSearchClose" href="javascript:searchBox.CloseResultsWindow()"><img id="MSearchCloseImg" border="0" src="search/close.png" alt=""/></a>
@@ -80,7 +80,7 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
       <div id="nav-sync" class="sync"></div>
     </div>
   </div>
-  <div id="splitbar" style="-moz-user-select:none;" 
+  <div id="splitbar" style="-moz-user-select:none;"
        class="ui-resizable-handle">
   </div>
 </div>
@@ -97,7 +97,7 @@ $(document).ready(function(){initNavTree('libsbml-sbml-specifications.html','');
 
 <!-- iframe showing the search results (closed by default) -->
 <div id="MSearchResultsWindow">
-<iframe src="javascript:void(0)" frameborder="0" 
+<iframe src="javascript:void(0)" frameborder="0"
         name="MSearchResults" id="MSearchResults">
 </iframe>
 </div>
@@ -123,7 +123,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -136,7 +136,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/formatted/csharp-api/libsbml-sbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/csharp-api/libsbml-sbml-specifications.html
@@ -63,8 +63,8 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
                onmouseout="return searchBox.OnSearchSelectHide()"
                alt=""/>
           <input type="text" id="MSearchField" value="Search" accesskey="S"
-               onfocus="searchBox.OnSearchFieldFocus(true)" 
-               onblur="searchBox.OnSearchFieldFocus(false)" 
+               onfocus="searchBox.OnSearchFieldFocus(true)"
+               onblur="searchBox.OnSearchFieldFocus(false)"
                onkeyup="searchBox.OnSearchFieldChange(event)"/>
           </span><span class="right">
             <a id="MSearchClose" href="javascript:searchBox.CloseResultsWindow()"><img id="MSearchCloseImg" border="0" src="search/close.png" alt=""/></a>
@@ -80,7 +80,7 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
       <div id="nav-sync" class="sync"></div>
     </div>
   </div>
-  <div id="splitbar" style="-moz-user-select:none;" 
+  <div id="splitbar" style="-moz-user-select:none;"
        class="ui-resizable-handle">
   </div>
 </div>
@@ -97,7 +97,7 @@ $(document).ready(function(){initNavTree('libsbml-sbml-specifications.html','');
 
 <!-- iframe showing the search results (closed by default) -->
 <div id="MSearchResultsWindow">
-<iframe src="javascript:void(0)" frameborder="0" 
+<iframe src="javascript:void(0)" frameborder="0"
         name="MSearchResults" id="MSearchResults">
 </iframe>
 </div>
@@ -123,7 +123,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -136,7 +136,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/formatted/java-api/libsbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/java-api/libsbml-specifications.html
@@ -98,7 +98,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -111,7 +111,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/formatted/matlab-api/libsbml-sbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/matlab-api/libsbml-sbml-specifications.html
@@ -50,7 +50,7 @@
       <div id="nav-sync" class="sync"></div>
     </div>
   </div>
-  <div id="splitbar" style="-moz-user-select:none;" 
+  <div id="splitbar" style="-moz-user-select:none;"
        class="ui-resizable-handle">
   </div>
 </div>
@@ -79,7 +79,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -92,7 +92,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/formatted/python-api/libsbml-sbml-specifications.html
+++ b/site/static/software/libsbml/5.18.0/docs/formatted/python-api/libsbml-sbml-specifications.html
@@ -63,8 +63,8 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
                onmouseout="return searchBox.OnSearchSelectHide()"
                alt=""/>
           <input type="text" id="MSearchField" value="Search" accesskey="S"
-               onfocus="searchBox.OnSearchFieldFocus(true)" 
-               onblur="searchBox.OnSearchFieldFocus(false)" 
+               onfocus="searchBox.OnSearchFieldFocus(true)"
+               onblur="searchBox.OnSearchFieldFocus(false)"
                onkeyup="searchBox.OnSearchFieldChange(event)"/>
           </span><span class="right">
             <a id="MSearchClose" href="javascript:searchBox.CloseResultsWindow()"><img id="MSearchCloseImg" border="0" src="search/close.png" alt=""/></a>
@@ -80,7 +80,7 @@ var searchBox = new SearchBox("searchBox", "search",false,'Search');
       <div id="nav-sync" class="sync"></div>
     </div>
   </div>
-  <div id="splitbar" style="-moz-user-select:none;" 
+  <div id="splitbar" style="-moz-user-select:none;"
        class="ui-resizable-handle">
   </div>
 </div>
@@ -97,7 +97,7 @@ $(document).ready(function(){initNavTree('libsbml-sbml-specifications.html','');
 
 <!-- iframe showing the search results (closed by default) -->
 <div id="MSearchResultsWindow">
-<iframe src="javascript:void(0)" frameborder="0" 
+<iframe src="javascript:void(0)" frameborder="0"
         name="MSearchResults" id="MSearchResults">
 </iframe>
 </div>
@@ -123,7 +123,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -136,7 +136,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/src/common-text/sbml-specifications-table.html
+++ b/site/static/software/libsbml/5.18.0/docs/src/common-text/sbml-specifications-table.html
@@ -14,7 +14,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -27,7 +27,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>

--- a/site/static/software/libsbml/5.18.0/docs/src/common-text/sbml-specifications-table.html.in
+++ b/site/static/software/libsbml/5.18.0/docs/src/common-text/sbml-specifications-table.html.in
@@ -14,7 +14,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom">
     <td style="white-space: nowrap">
-      <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-2">
+      <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-2">
         <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;2 Core (Release&nbsp;1)</a>
     </td>
     <td>
@@ -27,7 +27,7 @@ these documents.</caption>
 
 <tr class="align-text-bottom" style="border-bottom: 1px solid #aaa">
   <td style="white-space: nowrap">
-    <a class="spec-link" target="_blank" href="http://co.mbine.org/specifications/sbml.level-3.version-1">
+    <a class="spec-link" target="_blank" href="https://identifiers.org/combine.specifications:sbml.level-3.version-1">
       <img class="big-icon" width="22px" src="icon-format-pdf-44px.jpg">SBML Level&nbsp;3 Version&nbsp;1 Core (Release&nbsp;2)</a>
   </td>
   <td>


### PR DESCRIPTION
This fixes the broken links by switching to the identifiers.org links.
These can be automatically be fixed upstream and are future proof.
Please merge.